### PR TITLE
Fix for Duplicate Block Appender at Root Level in Block Editor (#62)

### DIFF
--- a/src/editor/block-appender.js
+++ b/src/editor/block-appender.js
@@ -11,10 +11,17 @@ wp.hooks.addFilter(
             return blockOrder[blockOrder.length - 1]; // Get the last block's clientId
         }, []);
 
+        const rootClientId = useSelect((select) =>
+            select('core/block-editor').getBlockRootClientId(props.clientId),
+            [props.clientId]
+        );
+        // Only show if it's the last root-level block (not inside reusable or inner blocks)
+        const shouldShowAppender = props.clientId === lastBlockClientId && rootClientId === null;
+
         return (
             <>
                 <BlockEdit {...props} />
-                {props.clientId === lastBlockClientId && (
+                {shouldShowAppender && (
                     <div className={'block-list-appender wp-block'}>
                         <ButtonBlockAppender
                             rootClientId={null} // Since we don't have nested blocks


### PR DESCRIPTION
### Summary
After a recent WordPress update, the editor started showing **two block appenders** ("+" buttons) at the bottom of the editor. This was caused by both:

- The custom block appender defined in our plugin.
- The default appender WordPress now adds at the root level.

### Related issues
Fixes #62

![image](https://github.com/user-attachments/assets/64e46d32-a2d5-494d-bbf3-7a1a8b741226)
