### PR TITLE
Fix: Prevent layout break from long text in Blueprint Gallery (#61)

### DIFF
--- a/src/editor/blueprint-gallery.js
+++ b/src/editor/blueprint-gallery.js
@@ -127,6 +127,7 @@ function Gallery({ onSubmitData }) {
                                                 lineHeight={'1.5em'}
                                                 size={15}   
                                                 color='#777'
+                                                style={{wordBreak: 'break-word'}}
                                             >
                                                 {blueprintDetails.description}
                                             </Text>


### PR DESCRIPTION
## Summary
This PR fixes a layout issue in the **Blueprint Gallery** modal where long text or URLs in the description would overflow and distort the card design.

### Fix
- Added `word-break: break-word` to the description text styles.
- This ensures all long strings wrap properly without breaking the layout.

### Related issues
Closes #61 

![image](https://github.com/user-attachments/assets/09523b61-7816-4a24-9555-bade049dd48f)
