### PR TITLE
feat: (#60) add onboarding modal with quick start options for new blueprints

### DIFF
--- a/src/editor/blueprint-gallery.js
+++ b/src/editor/blueprint-gallery.js
@@ -19,9 +19,10 @@ import {
 /**
  * Internal dependencies
  */
-import { handleBlueprintData } from './utils';
+import { handleBlueprintData, useBlueprintData } from './utils';
 
-function Gallery({ onSubmitData }) {
+function Gallery({ label = 'Gallery', icon = null, onClick }) {
+    const { updateBlueprintConfig } = useBlueprintData();
     const { createNotice } = useDispatch(noticesStore);
     const [isModalOpen, setModalOpen] = useState(false);
     const [blueprintList, setBlueprintList] = useState(null);
@@ -59,14 +60,14 @@ function Gallery({ onSubmitData }) {
         },
         steps: []
     };
-    
+
     const fetchBlueprintDetails = async (blueprintName) => {
         const blueprintUrl = `https://raw.githubusercontent.com/WordPress/blueprints/trunk/${blueprintName}`;
         try {
             const response = await fetch(blueprintUrl);
             if (!response.ok) throw new Error(`Failed to fetch blueprint details: ${response.statusText}`);
             const data = await response.json();
-    
+
             // Ensure default values for required properties
             const validatedData = {
                 preferredVersions: data.preferredVersions || defaultValues.preferredVersions,
@@ -74,15 +75,15 @@ function Gallery({ onSubmitData }) {
                 steps: data.steps || defaultValues.steps,
                 ...data, // Merge in other properties from the fetched data
             };
-    
+
             // Merge the updated steps and other data with default values
             const mergedData = {
                 ...defaultValues,
                 ...validatedData,
             };
-            
+
             // Pass the processed data to the handler
-            handleBlueprintData(mergedData, createNotice, onSubmitData);
+            handleBlueprintData(mergedData, createNotice, updateBlueprintConfig);
         } catch (error) {
             createNotice('error', __('Error fetching blueprint from Gallery', 'wp-playground-blueprint-editor') + `: ${error.message}`);
         }
@@ -93,9 +94,15 @@ function Gallery({ onSubmitData }) {
             {/* Open modal button */}
             <Button
                 className='blueprint_gallery_json'
-                __next40pxDefaultSize
-                onClick={() => setModalOpen(true)}>
-                {__('Gallery', 'wp-playground-blueprint-editor')}
+                onClick={() => setModalOpen(true)}
+                icon={icon}
+                style={{
+                    height: '100%',
+                    flexDirection: 'column',
+                    padding: '13px'
+                }}
+            >
+                {__(label, 'wp-playground-blueprint-editor')}
             </Button>
 
             {/* Blueprint gallery modal */}
@@ -125,21 +132,21 @@ function Gallery({ onSubmitData }) {
                                             </Text>
                                             <Text
                                                 lineHeight={'1.5em'}
-                                                size={15}   
+                                                size={15}
                                                 color='#777'
                                                 style={{wordBreak: 'break-word'}}
                                             >
                                                 {blueprintDetails.description}
                                             </Text>
-                                            </VStack>
+                                        </VStack>
                                         {/* Action Button */}
                                         <Button
                                             variant="secondary"
                                             style={{
                                                 borderRadius: '4px',
-                                                alignSelf: 'flex-end',   
+                                                alignSelf: 'flex-end',
                                             }}
-                                            onClick={() => fetchBlueprintDetails(blueprintName)}
+                                            onClick={() => { fetchBlueprintDetails(blueprintName), onClick(onClick) }}
                                         >
                                             {__('Import', 'wp-playground-blueprint-editor')}
                                         </Button>

--- a/src/editor/blueprint-gallery.js
+++ b/src/editor/blueprint-gallery.js
@@ -21,7 +21,7 @@ import {
  */
 import { handleBlueprintData, useBlueprintData } from './utils';
 
-function Gallery({ label = 'Gallery', icon = null, onClick }) {
+function Gallery({ label = 'Gallery', icon = null, handleClose }) {
     const { updateBlueprintConfig } = useBlueprintData();
     const { createNotice } = useDispatch(noticesStore);
     const [isModalOpen, setModalOpen] = useState(false);
@@ -146,7 +146,7 @@ function Gallery({ label = 'Gallery', icon = null, onClick }) {
                                                 borderRadius: '4px',
                                                 alignSelf: 'flex-end',
                                             }}
-                                            onClick={() => { fetchBlueprintDetails(blueprintName), onClick(onClick) }}
+                                            onClick={() => { fetchBlueprintDetails(blueprintName); handleClose(); }}
                                         >
                                             {__('Import', 'wp-playground-blueprint-editor')}
                                         </Button>

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -1,2 +1,3 @@
 import './block-appender';
 import './sidebar';
+import './onboarding'

--- a/src/editor/onboarding.js
+++ b/src/editor/onboarding.js
@@ -41,15 +41,15 @@ const OnboardingModal = () => {
 
     return (
         <Modal
-            title={__('Start Building Your Blueprint', 'wp-playground-blueprint-editor')}
+            title={__('Start Blueprint From', 'wp-playground-blueprint-editor')}
             onRequestClose={handleClose}
             shouldCloseOnClickOutside
             shouldCloseOnEsc
             size="medium"
         >
             <Grid columns={3} spacing={4}>
-                <OpenJson label='Json' icon={code} onClick={handleClose} />
-                <Gallery label='Gallery' icon={gallery} onClick={handleClose} />
+                <OpenJson label='JSON' icon={code} handleClose={handleClose} />
+                <Gallery label='Gallery' icon={gallery} handleClose={handleClose} />
                 <Button
                     onClick={handleClose}
                     icon={plus}
@@ -60,7 +60,7 @@ const OnboardingModal = () => {
                         padding: '13px'
                     }}
                 >
-                    {__('Start Blank', 'wp-playground-blueprint-editor')}
+                    {__('Blank', 'wp-playground-blueprint-editor')}
                 </Button>
                 <Button variant="tertiary" onClick={handleClose}>
                     {__('Skip', 'wp-playground-blueprint-editor')}

--- a/src/editor/onboarding.js
+++ b/src/editor/onboarding.js
@@ -62,9 +62,6 @@ const OnboardingModal = () => {
                 >
                     {__('Blank', 'wp-playground-blueprint-editor')}
                 </Button>
-                <Button variant="tertiary" onClick={handleClose}>
-                    {__('Skip', 'wp-playground-blueprint-editor')}
-                </Button>
             </Grid>
         </Modal>
     );

--- a/src/editor/onboarding.js
+++ b/src/editor/onboarding.js
@@ -1,0 +1,75 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState, useEffect } from '@wordpress/element';
+import {
+    Button,
+    Modal,
+    __experimentalGrid as Grid,
+} from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { registerPlugin } from '@wordpress/plugins';
+import { code, gallery, plus } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import Gallery from './blueprint-gallery';
+import OpenJson from './open-json';
+
+const OnboardingModal = () => {
+    const [showModal, setShowModal] = useState(false);
+
+    const { isNewPost, blocks } = useSelect((select) => {
+        const editor = select('core/editor');
+        return {
+            isNewPost: editor.isCleanNewPost(),
+            blocks: editor.getBlocks(),
+        };
+    }, []);
+
+    useEffect(() => {
+        if (isNewPost && blocks.length === 0) {
+            setShowModal(true);
+        }
+    }, [isNewPost, blocks]);
+
+    const handleClose = () => setShowModal(false);
+
+    if (!showModal) return null;
+
+    return (
+        <Modal
+            title={__('Start Building Your Blueprint', 'wp-playground-blueprint-editor')}
+            onRequestClose={handleClose}
+            shouldCloseOnClickOutside
+            shouldCloseOnEsc
+            size="medium"
+        >
+            <Grid columns={3} spacing={4}>
+                <OpenJson label='Json' icon={code} onClick={handleClose} />
+                <Gallery label='Gallery' icon={gallery} onClick={handleClose} />
+                <Button
+                    onClick={handleClose}
+                    icon={plus}
+                    style={{
+                        boxShadow: 'inset 0 0 0 1px #ccc',
+                        height: '100%',
+                        flexDirection: 'column',
+                        padding: '13px'
+                    }}
+                >
+                    {__('Start Blank', 'wp-playground-blueprint-editor')}
+                </Button>
+                <Button variant="tertiary" onClick={handleClose}>
+                    {__('Skip', 'wp-playground-blueprint-editor')}
+                </Button>
+            </Grid>
+        </Modal>
+    );
+};
+
+registerPlugin('wp-blueprint-onboarding', {
+    render: OnboardingModal,
+});

--- a/src/editor/open-json.js
+++ b/src/editor/open-json.js
@@ -1,24 +1,31 @@
 import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
-import { FormFileUpload, DropZone } from '@wordpress/components';
+import { FormFileUpload, DropZone, Spinner } from '@wordpress/components';
 import { store as noticesStore } from '@wordpress/notices';
 import { handleBlueprintData, useBlueprintData } from './utils'
+import { useState } from '@wordpress/element';
 
 const OpenJson = ({ label = 'Open', icon = null, handleClose }) => {
     const { createNotice } = useDispatch(noticesStore);
     const { updateBlueprintConfig } = useBlueprintData();
+    const [isUploadingJson, setIsUploadingJson] = useState(false);
 
     // Process JSON file content
-    const processJsonFile = (file) => {
+    const processJsonFile = async (file) => {
         if (file.type === 'application/json') {
             const reader = new FileReader();
-            reader.onload = () => {
+            reader.onload = async () => {
                 try {
                     const jsonData = JSON.parse(reader.result);
-                    handleBlueprintData(jsonData, createNotice, updateBlueprintConfig);
+                    setIsUploadingJson(true); // Show spinner
+                    await handleBlueprintData(jsonData, createNotice, updateBlueprintConfig);
+                    if (handleClose) handleClose();
                 }
                 catch (err) {
                     createNotice('error', __('Invalid JSON file.', 'wp-playground-blueprint-editor'));
+                }
+                finally {
+                    setIsUploadingJson(false); // Hide spinner
                 }
             };
             reader.readAsText(file);
@@ -32,7 +39,6 @@ const OpenJson = ({ label = 'Open', icon = null, handleClose }) => {
         const file = event.target.files[0];
         if (file) {
             processJsonFile(file);
-            handleClose();
         }
     };
 
@@ -50,15 +56,22 @@ const OpenJson = ({ label = 'Open', icon = null, handleClose }) => {
             className='upload_blueprint_json'
             accept="application/json"
             onChange={handleFileSelection}
-            icon={icon}
+            icon={null}
             style={{
                 height: '100%',
                 flexDirection: 'column',
-                padding:'13px'
+                padding: '13px'
             }}
-            >
-            {__(label, 'wp-playground-blueprint-editor')}
-
+        >
+            {!isUploadingJson && (<>
+                {icon && (
+                    <span style={{ width: 24, height: 24, display: 'inline-block' }}>
+                        {icon}
+                    </span>
+                )}
+                {__(label, 'wp-playground-blueprint-editor')}
+            </>)}
+            {isUploadingJson && (<Spinner style={{ margin: 0 }} />)}
             <DropZone
                 onFilesDrop={handleFileDrop}
                 accept="application/json"

--- a/src/editor/open-json.js
+++ b/src/editor/open-json.js
@@ -1,11 +1,12 @@
 import { __ } from '@wordpress/i18n';
-import {  useDispatch } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { FormFileUpload, DropZone } from '@wordpress/components';
 import { store as noticesStore } from '@wordpress/notices';
-import {handleBlueprintData} from './utils'
+import { handleBlueprintData, useBlueprintData } from './utils'
 
-const OpenJson = ({ onSubmitData }) => {
+const OpenJson = ({ label = 'Open', icon = null, onClick }) => {
     const { createNotice } = useDispatch(noticesStore);
+    const { updateBlueprintConfig } = useBlueprintData();
 
     // Process JSON file content
     const processJsonFile = (file) => {
@@ -14,7 +15,7 @@ const OpenJson = ({ onSubmitData }) => {
             reader.onload = () => {
                 try {
                     const jsonData = JSON.parse(reader.result);
-                    handleBlueprintData(jsonData , createNotice, onSubmitData); 
+                    handleBlueprintData(jsonData, createNotice, updateBlueprintConfig);
                 }
                 catch (err) {
                     createNotice('error', __('Invalid JSON file.', 'wp-playground-blueprint-editor'));
@@ -31,6 +32,7 @@ const OpenJson = ({ onSubmitData }) => {
         const file = event.target.files[0];
         if (file) {
             processJsonFile(file);
+            onClick(onClick);
         }
     };
 
@@ -46,11 +48,17 @@ const OpenJson = ({ onSubmitData }) => {
     return (
         <FormFileUpload
             className='upload_blueprint_json'
-            __next40pxDefaultSize
             accept="application/json"
             onChange={handleFileSelection}
-        >
-            {__('Open', 'wp-playground-blueprint-editor')}
+            icon={icon}
+            style={{
+                height: '100%',
+                flexDirection: 'column',
+                padding:'13px'
+            }}
+            >
+            {__(label, 'wp-playground-blueprint-editor')}
+
             <DropZone
                 onFilesDrop={handleFileDrop}
                 accept="application/json"

--- a/src/editor/open-json.js
+++ b/src/editor/open-json.js
@@ -4,7 +4,7 @@ import { FormFileUpload, DropZone } from '@wordpress/components';
 import { store as noticesStore } from '@wordpress/notices';
 import { handleBlueprintData, useBlueprintData } from './utils'
 
-const OpenJson = ({ label = 'Open', icon = null, onClick }) => {
+const OpenJson = ({ label = 'Open', icon = null, handleClose }) => {
     const { createNotice } = useDispatch(noticesStore);
     const { updateBlueprintConfig } = useBlueprintData();
 
@@ -32,7 +32,7 @@ const OpenJson = ({ label = 'Open', icon = null, onClick }) => {
         const file = event.target.files[0];
         if (file) {
             processJsonFile(file);
-            onClick(onClick);
+            handleClose();
         }
     };
 

--- a/src/editor/sidebar.js
+++ b/src/editor/sidebar.js
@@ -5,8 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 import { PluginDocumentSettingPanel, PluginPostStatusInfo } from '@wordpress/editor';
 import { copy, download, globe, code } from '@wordpress/icons';
-import { useCallback } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import { useCopyToClipboard } from '@wordpress/compose';
 import { downloadBlob } from '@wordpress/blob';
@@ -30,57 +29,20 @@ import { PHP_VERSIONS, WP_VERSIONS, PLAYGROUND_BASE, PLAYGROUND_BUILDER_BASE, PL
 import Gallery from './blueprint-gallery';
 import SiteOptionsSettings from './site-options-settings';
 import PluginSettings from './plugins-settings';
+import { useBlueprintData } from './utils';
 
 /**
  * Main component for displaying blueprint sidebar setting.
  */
 function BlueprintSidebarSettings() {
-    const { createErrorNotice, createSuccessNotice } = useDispatch(noticesStore);
-    const { editPost } = useDispatch('core/editor');
+    const createNotice = useDispatch(noticesStore);
+    const {
+        schema,
+        prepareSchema,
+        updateBlueprintConfig,
+        blueprint_config,
+    } = useBlueprintData();
 
-    const blocks = useSelect((select) => select('core/block-editor').getBlocks(), []);
-    const blueprint_config = useSelect((select) => {
-        return select('core/editor').getEditedPostAttribute('meta')['_blueprint_config'] || {}
-    });
-
-    const schema = {
-        $schema: PLAYGROUND_BLUEPRINT_SCHEMA_URL,
-        landingPage: blueprint_config.landing_page,
-        preferredVersions: {
-            php: blueprint_config.php_version,
-            wp: blueprint_config.wp_version
-        },
-        phpExtensionBundles: [blueprint_config.php_extension_bundles],
-        features: blueprint_config.networking ? { networking: true } : {},
-        login: blueprint_config.login,
-        siteOptions: blueprint_config.siteOptions,
-        extraLibraries: blueprint_config.extra_libraries,
-        plugins: blueprint_config.plugins,
-        steps: []
-    };
-
-    /**
-     * Prepares the schema by extracting attributes from blocks.
-     * Blocks' metadata is excluded to keep the schema clean.
-     */
-    const prepareSchema = useCallback(() => {
-        const blockAttributes = blocks.map((block) => {
-            const { metadata, ...rest } = block.attributes; // Exclude metadata
-            return rest;
-        });
-        schema.steps = blockAttributes;
-        // Conditionally include the `login` property only if it's true
-        const cleanedSchema = {
-            ...schema,
-            login: blueprint_config.login ? blueprint_config.login : undefined,
-            siteOptions: blueprint_config.siteOptions && Object.keys(blueprint_config.siteOptions).length > 0
-                ? blueprint_config.siteOptions : undefined, // Include only if siteOptions is non-empty
-            extraLibraries: blueprint_config.extra_libraries && ['wp-cli'] || undefined,
-            plugins: blueprint_config.plugins && Object(blueprint_config.plugins).length > 0
-                ? blueprint_config.plugins : undefined, // Include only if plugins is non-empty
-        };
-        return JSON.stringify(cleanedSchema, null, 2); // Format the schema as a pretty JSON string
-    }, [blocks, schema, blueprint_config]);
     /**
      * Handles downloading the prepared schema as a JSON file.
      */
@@ -88,9 +50,9 @@ function BlueprintSidebarSettings() {
         try {
             const preparedSchema = prepareSchema();
             downloadBlob('playground-blueprint.json', preparedSchema, 'application/json');
-            createSuccessNotice(__('Blueprint downloaded successfully!', 'wp-playground-blueprint-editor'), { type: 'snackbar' });
+            createNotice('success', __('Blueprint downloaded successfully!', 'wp-playground-blueprint-editor'), { type: 'snackbar' });
         } catch (error) {
-            createErrorNotice(__('Failed to download Blueprint JSON.', 'wp-playground-blueprint-editor'));
+            createNotice('error', __('Failed to download Blueprint JSON.', 'wp-playground-blueprint-editor'));
         }
     };
 
@@ -99,44 +61,13 @@ function BlueprintSidebarSettings() {
      */
     const handleCopy = useCopyToClipboard(() => {
         if (!schema.steps.length) {
-            createErrorNotice(__('No Blueprint steps to copy!', 'wp-playground-blueprint-editor'));
+            createNotice('error', __('No Blueprint steps to copy!', 'wp-playground-blueprint-editor'));
             return ''; // Return empty string for invalid data
         }
-        createSuccessNotice(__('Blueprint schema copied to clipboard!', 'wp-playground-blueprint-editor'), { type: 'snackbar' });
+        createNotice('success', __('Blueprint schema copied to clipboard!', 'wp-playground-blueprint-editor'), { type: 'snackbar' });
         return prepareSchema();
     });
 
-    /**
-     * Updates the blueprint configuration stored in the post meta.
-     * @param {Object} updatedValues - Partial blueprint configuration to update.
-     */
-    const updateBlueprintConfig = (updatedValues) => {
-        editPost({ meta: { _blueprint_config: { ...blueprint_config, ...updatedValues } } });
-    };
-
-    /**
-     * Handles JSON data submission from the upload modal.
-     * Transforms the uploaded JSON to match the blueprint configuration format.
-     * @param {Object} data - Uploaded JSON data.
-     */
-    const handleJsonDataSubmit = (data) => {
-        if (!data) {
-            createErrorNotice(__('Failed to update Blueprint configuration.', 'wp-playground-blueprint-editor'));
-            return;
-        }
-        updateBlueprintConfig({
-            landing_page: data.landingPage,
-            php_version: data.preferredVersions.php,
-            wp_version: data.preferredVersions.wp,
-            php_extension_bundles: data.phpExtensionBundles,
-            networking: data.features.networking || false,
-            login: data.login || false,
-            siteOptions: data.siteOptions || undefined,
-            extra_libraries: data.extraLibraries || undefined,
-            plugins: data.plugins || undefined,
-        });
-        createSuccessNotice(__('Blueprint configuration updated successfully!', 'wp-playground-blueprint-editor'), { type: 'snackbar' });
-    };
 
     return (
         <>
@@ -144,10 +75,10 @@ function BlueprintSidebarSettings() {
                 <VStack spacing={5} style={{ width: '100%' }}>
                     <Flex>
                         <FlexBlock>
-                            <OpenJson onSubmitData={handleJsonDataSubmit} />
+                            <OpenJson />
                         </FlexBlock>
                         <FlexBlock>
-                            <Gallery onSubmitData={handleJsonDataSubmit} />
+                            <Gallery />
                         </FlexBlock>
                     </Flex>
                     <Toolbar style={{ justifyContent: 'space-between' }}>

--- a/src/editor/sidebar.js
+++ b/src/editor/sidebar.js
@@ -35,7 +35,7 @@ import { useBlueprintData } from './utils';
  * Main component for displaying blueprint sidebar setting.
  */
 function BlueprintSidebarSettings() {
-    const createNotice = useDispatch(noticesStore);
+    const { createNotice } = useDispatch(noticesStore);
     const {
         schema,
         prepareSchema,


### PR DESCRIPTION
### Summary

This PR introduces an onboarding modal that appears when users start a new post with no existing blocks. The modal offers three entry points: JSON, Gallery, Start Blank or Skip, significantly improving the user experience for blueprint creation.

In addition, this PR decouples the BlueprintSidebarSettings logic by extracting schema preparation and configuration handling into a separate utility. This allows for cleaner data flow, especially between OpenJson, Gallery, and the sidebar. Now, when data is submitted via those components, it directly integrates into the blueprint sidebar without additional transformation layers.

### Related Issue

Closes #60

### Checklist

- [x] Onboarding modal added with three primary actions and skip option
- [x] Schema preparation logic moved out of BlueprintSidebarSettings
- [x] UX and code maintainability improved

### Screen Recording

https://github.com/user-attachments/assets/1fbd144a-5f2d-4793-a5cc-80279e9778ad

Shared a video showcasing the updated behavior after addressing all feedback

https://github.com/user-attachments/assets/05942158-ccd9-4373-91ae-39473e6048e8



